### PR TITLE
Fix debug configuration for VisualStudio project

### DIFF
--- a/Logik.MultiAiCoder.VS.UI/Logik.MultiAiCoder.VisualStudio.UIControls.csproj
+++ b/Logik.MultiAiCoder.VS.UI/Logik.MultiAiCoder.VisualStudio.UIControls.csproj
@@ -48,6 +48,9 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
     <Page Include="Themes\Generic.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Logik.MultiAiCoder.VisualStudio/Logik.MultiAiCoder.VisualStudio.csproj
+++ b/Logik.MultiAiCoder.VisualStudio/Logik.MultiAiCoder.VisualStudio.csproj
@@ -37,6 +37,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DeployExtension>true</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -83,6 +84,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" NoWarn="NU1604" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2094" NoWarn="NU1604" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="UI\AddPromptWindow.xaml">
@@ -99,7 +101,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Logik.MultiAICoder.Engine\Logik.MultiAiCoder.Engine.csproj">
+    <ProjectReference Include="..\Logik.MultiAICoder.Engine\Logik.MultiAICoder.Engine.csproj">
       <Project>{ad98984b-39c1-44ba-b3eb-23621b19c3dd}</Project>
       <Name>Logik.MultiAiCoder.Engine</Name>
     </ProjectReference>
@@ -109,7 +111,8 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+  <Import Project="$(PkgMicrosoft_VSSDK_BuildTools)/tools/vssdk/Microsoft.VsSDK.targets" Condition="Exists('$(PkgMicrosoft_VSSDK_BuildTools)/tools/vssdk/Microsoft.VsSDK.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Logik.MultiAiCoder.sln
+++ b/Logik.MultiAiCoder.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logik.MultiAiCoder.Engine", "Logik.MultiAICoder.Engine\Logik.MultiAiCoder.Engine.csproj", "{AD98984B-39C1-44BA-B3EB-23621B19C3DD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logik.MultiAiCoder.Engine", "Logik.MultiAICoder.Engine\Logik.MultiAICoder.Engine.csproj", "{AD98984B-39C1-44BA-B3EB-23621B19C3DD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logik.MultiAiCoder.VisualStudio.UIControls", "Logik.MultiAiCoder.VS.UI\Logik.MultiAiCoder.VisualStudio.UIControls.csproj", "{8AFCF238-BA5E-4662-8AC3-FB2D9355CDF4}"
 EndProject


### PR DESCRIPTION
## Summary
- correct engine project path in solution
- include .NET Framework reference assemblies for UI and VS projects
- ensure DeployExtension property is set for debugging
- import VSSDK targets from NuGet when Visual Studio targets are missing

## Testing
- `dotnet build Logik.MultiAiCoder.sln` *(fails: Microsoft.VisualStudio references missing on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_685bf33bd4d8832ca20bd5d7b358d096